### PR TITLE
added downsampling acceleration and rotation support

### DIFF
--- a/configs/params.yaml
+++ b/configs/params.yaml
@@ -1,9 +1,11 @@
 nonrigid_registration:
   autotune: 'False'
-  beta: 0.5
+  gamma: 10
+  beta: 2
   decimation: 'False'
   distance_threshold: 1e-8
-  lambda: 50
+  lambda: 10
+  downsampling: 'Y, 26443, 0.05'
   max_iterations: 1000
   seed: 26
 rigid_registration:

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -67,9 +67,10 @@ class Pipeline():
                                  source=source, 
                                  target=target,
                                  params=self.params,
-                                 registration=to_mesh(self.steps['denormalize_rigid'].output['Source'], source.faces),
+                                 registration=to_mesh(self.steps['denormalize_rigid'].output['Source'], source.faces, process=False),
                                  transformations=[(name, step.transform['Source']) for name, step in self.steps.items() if step.transform])
 
+        # return projections
         return projections
 
     def compute_metrics(self, metric: str):

--- a/src/utils/conversions.py
+++ b/src/utils/conversions.py
@@ -40,11 +40,11 @@ def to_pointcloud(geometry):
     else: 
         return geometry
     
-def to_mesh(geometry, faces):
+def to_mesh(geometry, faces, process=True):
     if isinstance(geometry, np.ndarray):
-        return numpy_to_mesh(geometry, faces)
+        return numpy_to_mesh(geometry, faces, process)
     elif isinstance(geometry, o3d.geometry.PointCloud):
-        return pointcloud_to_mesh(geometry, faces)
+        return pointcloud_to_mesh(geometry, faces, process)
     else: 
         return geometry
 
@@ -66,15 +66,15 @@ def numpy_to_pointcloud(numpy_array: np.ndarray) -> o3d.geometry.PointCloud:
     pcd.estimate_normals()
     return pcd
 
-def numpy_to_mesh(numpy_array: np.ndarray, faces: np.ndarray) -> trimesh.base.Trimesh:
-    return trimesh.Trimesh(vertices=numpy_array, faces=faces)
+def numpy_to_mesh(numpy_array: np.ndarray, faces: np.ndarray, process=True) -> trimesh.base.Trimesh:
+    return trimesh.Trimesh(vertices=numpy_array, faces=faces, process=process)
 
 def pointcloud_to_numpy(pointcloud: o3d.geometry.PointCloud) -> np.ndarray:
     return np.array(pointcloud.points)
 
-def pointcloud_to_mesh(pointcloud: o3d.geometry.PointCloud, faces: np.ndarray) -> o3d.geometry.PointCloud:
+def pointcloud_to_mesh(pointcloud: o3d.geometry.PointCloud, faces: np.ndarray, process=True) -> o3d.geometry.PointCloud:
     """Converts a open3d point cloud object to trimesh mesh object"""
-    return trimesh.Trimesh(vertices=np.array(pointcloud.points), faces=faces)
+    return trimesh.Trimesh(vertices=np.array(pointcloud.points), faces=faces, process=process)
 
 def txt_to_numpy(path: str) -> np.ndarray:
     """Converts an array saved as a text to a numpy object"""


### PR DESCRIPTION
This pull request makes the following changes:

1. Adds support for downsampling and rotation. Downsampling reduces memory pressure for very large point clouds, as well accelerates the registration process. 
2. Enforces the same vertex count post calculating projections by enabling the `process=False` argument while constructing the meshes back